### PR TITLE
fix: minimum ruby version 3.1.0

### DIFF
--- a/bloomr.gemspec
+++ b/bloomr.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Write a longer description or delete this line."
   spec.homepage = "https://github.com/eo-sdev/bloomr"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.1.0"
 
   spec.metadata["allowed_push_host"] = spec.homepage
 


### PR DESCRIPTION
SDK implemented using a ruby feature only available on 3.1 https://bugs.ruby-lang.org/issues/14579

Here is the error when using the SDK with a version <= 3.1

```
/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/gems/3.0.0/gems/bloomr-0.1.0/lib/bloomr.rb:9:in `require_relative': /Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/gems/3.0.0/gems/bloomr-0.1.0/lib/bloomr/http.rb:27: syntax error, unexpected ',' (SyntaxError)
...sg = { type: :request, method:, url:, body:, headers: }
...                              ^
	from /Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/gems/3.0.0/gems/bloomr-0.1.0/lib/bloomr.rb:9:in `<top (required)>'
	from <internal:/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:160:in `require'
	from <internal:/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:160:in `rescue in require'
	from <internal:/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:149:in `require'
	from app.rb:1:in `<main>'
<internal:/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- bloomr (LoadError)
	from <internal:/Users/stefanmikolajczyk/.asdf/installs/ruby/3.0.7/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from app.rb:1:in `<main>'
```