### PR TITLE
fix: README now includes require

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 ## Usage
 
 ```
+require('bloomr')
+
 api = Bloomr::Api.new(
     api_url_base: 'https://sandbox.bloom.dev',
     auth_url_base: 'https://auth.bloom.dev',


### PR DESCRIPTION
Fix in readme:
- missing `require`