### PR TITLE
fix: register_consumer

### DIFF
--- a/lib/bloomr/consumer.rb
+++ b/lib/bloomr/consumer.rb
@@ -55,7 +55,7 @@ module Bloomr
         ip_address: consumer_info['ip_address'],
         name: name,
         phones: phones
-      }.compact
+      }.compact.reject { |_, v| v.nil? || v.empty?  }
 
       body = {
         data: {
@@ -70,7 +70,7 @@ module Bloomr
       }
 
       response = request('/v2/core/consumers', :post, body, headers)
-      response['data']['id']
+      response[:data][:id]
     end
   end
 end


### PR DESCRIPTION
currently the implementation is non-functional with the current API implementation. Two fixes are done in this PR.
First: the `Emails` field supplied with the API when empty should be removed from the payload. Currently, if not given (as within the README), it will result in a empty object '{}'. The fix removes said object.

The second fix lies in the fetch of the consumer_id that wasn't done by symbol and crashes at runtime.